### PR TITLE
Preserve spaces in animated hero headline

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -7,7 +7,13 @@ document.addEventListener('DOMContentLoaded', () => {
   headline.innerHTML = '';
   [...text].forEach((char, i) => {
     const span = document.createElement('span');
-    span.textContent = char;
+    if (char === ' ') {
+      span.innerHTML = '&nbsp;';
+      span.style.display = 'inline';
+    } else {
+      span.textContent = char;
+      span.style.display = 'inline-block';
+    }
     span.style.transitionDelay = `${i * 50}ms`;
     headline.appendChild(span);
   });


### PR DESCRIPTION
## Summary
- ensure hero headline animation retains spaces by converting them to non-breaking spaces and avoiding inline-block display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c2285d4c832e988daa4a23ca0528