### PR TITLE
Add live demo and hero animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,9 @@
   <section id="mission" class="hero">
     <h1>Empowering Safer Surgery Through AI‑Driven EMG, SSEP &amp; MEP Models</h1>
     <p>Real‑time alerts and recommendations to enhance intraoperative monitoring.</p>
-    <a href="#solution" class="btn">Watch Demo</a>
+    <a href="#live-demo" class="btn">Watch Demo</a>
     <div class="scroll-indicator"></div>
+    <canvas id="heroParticles" aria-hidden="true"></canvas>
   </section>
 
   <!-- Need Section -->
@@ -58,7 +59,7 @@
   <section id="solution">
     <h2>Our Solution</h2>
     <div class="solution">
-      <img src="assets/images/team1.svg" alt="AI illustration" />
+      <img src="assets/images/hero_or_ai.svg" alt="Stylized AI neuromonitoring illustration" />
       <div>
         <p>NotNervio leverages deep‑learning models trained on EMG, SSEP and MEP data to deliver real‑time alerts during surgery.</p>
         <p>By converting complex neuro signals into clear guidance, surgeons can respond faster and keep patients safer.</p>
@@ -66,9 +67,38 @@
     </div>
   </section>
 
+  <!-- Live Demo -->
+  <section id="live-demo" class="live-demo">
+    <h2>Live AI Monitor (Demo)</h2>
+    <p class="demo-sub">Simulated EMG/SSEP/MEP streams with real-time alerts.</p>
+
+    <div class="monitor">
+      <canvas id="emgCanvas" width="900" height="120" aria-label="EMG waveform"></canvas>
+      <canvas id="ssepCanvas" width="900" height="120" aria-label="SSEP waveform"></canvas>
+      <canvas id="mepCanvas" width="900" height="120" aria-label="MEP waveform"></canvas>
+    </div>
+
+    <div class="demo-controls">
+      <button id="demoToggle" class="btn" aria-pressed="false">Start Demo</button>
+      <label class="speed">
+        <span>Speed</span>
+        <input id="demoSpeed" type="range" min="0.5" max="2" step="0.1" value="1">
+      </label>
+    </div>
+
+    <div id="alertBar" class="alert-bar" role="status" aria-live="polite">
+      <span class="pill quiet">Quiet</span>
+      <span class="pill ok">Stable</span>
+    </div>
+  </section>
+
   <!-- Features Section -->
   <section id="features">
     <h2>Features</h2>
+    <picture>
+      <source srcset="assets/images/signals_collage.svg" type="image/svg+xml">
+      <img src="assets/images/signals_collage.svg" alt="EMG, SSEP and MEP visual collage" style="width:100%;max-width:900px;display:block;margin:0 auto 1rem;">
+    </picture>
     <div class="features-grid">
       <div class="feature-item hidden">
         <i class="fas fa-chart-line"></i>
@@ -91,6 +121,11 @@
         <p>Faster clinical alerts with clear visuals</p>
       </div>
     </div>
+  </section>
+
+  <section>
+    <h2>Model Overview</h2>
+    <img src="assets/images/model_cards.svg" alt="Model cards overview" style="width:100%;max-width:900px;display:block;margin:0 auto;">
   </section>
 
   <!-- Testimonials Section -->

--- a/scripts.js
+++ b/scripts.js
@@ -67,3 +67,119 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 });
+
+// === Live Demo: simple signal generator + fake alerts ===
+(function(){
+  const cfg = {
+    width: 900, height: 120,
+    speed: 1,
+    noise: 0.15,
+    colors: { stroke: '#3d7fff', grid: '#14254d' }
+  };
+
+  const canvases = [
+    { id: 'emgCanvas', label: 'EMG', baseFreq: 6.5, spikes: true },
+    { id: 'ssepCanvas', label: 'SSEP', baseFreq: 1.5, blocky: true },
+    { id: 'mepCanvas', label: 'MEP', baseFreq: 0.9, burst: true }
+  ].map(row => ({ ...row, el: document.getElementById(row.id), x: 0 }));
+
+  const alertBar = document.getElementById('alertBar');
+  const toggle = document.getElementById('demoToggle');
+  const speedInput = document.getElementById('demoSpeed');
+
+  let running = false, rafId = null, t = 0;
+
+  function grid(ctx, w, h){
+    ctx.strokeStyle = cfg.colors.grid;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let x = 0; x < w; x += 60) { ctx.moveTo(x, 0); ctx.lineTo(x, h); }
+    for (let y = 0; y < h; y += 30) { ctx.moveTo(0, y); ctx.lineTo(w, y); }
+    ctx.stroke();
+  }
+  function drawWave(ctx, w, h, baseFreq, style){
+    ctx.strokeStyle = cfg.colors.stroke; ctx.lineWidth = 2; ctx.beginPath();
+    for (let x = 0; x < w; x++) {
+      const px = (t + x) / 60;
+      let y = Math.sin(px * baseFreq);
+      if (style.spikes && Math.random() < 0.008) y += (Math.random() * 2 - 1) * 2.6;
+      if (style.blocky) y = Math.round(y*2)/2;
+      if (style.burst) y += Math.sin(px*12) * Math.exp(-((x-450)**2)/20000);
+      y += (Math.random()*2 - 1) * cfg.noise;
+      const py = h/2 + y * (h*0.35);
+      if (x === 0) ctx.moveTo(x, py); else ctx.lineTo(x, py);
+    }
+    ctx.stroke();
+  }
+  function paintRow(row){
+    const { el, baseFreq, spikes, blocky, burst } = row;
+    if (!el) return;
+    const ctx = el.getContext('2d');
+    const w = el.width = cfg.width, h = el.height = cfg.height;
+    ctx.clearRect(0,0,w,h);
+    grid(ctx, w, h);
+    drawWave(ctx, w, h, baseFreq, { spikes, blocky, burst });
+  }
+  function cycleAlerts(){
+    // Fake alert states
+    const r = Math.random();
+    alertBar.innerHTML = '';
+    if (r < 0.75) {
+      alertBar.append(elPill('Quiet','quiet'));
+      alertBar.append(elPill('Stable','ok'));
+    } else if (r < 0.92) {
+      alertBar.append(elPill('Check SSEP amplitude','warn'));
+    } else {
+      alertBar.append(elPill('ALERT: Possible pedicle irritation (EMG)','alert'));
+    }
+  }
+  function elPill(text, cls){
+    const s = document.createElement('span'); s.className = `pill ${cls}`; s.textContent = text; return s;
+  }
+  function loop(){
+    if (!running) return;
+    t += cfg.speed * 2;
+    canvases.forEach(paintRow);
+    if (Math.random() < 0.04) cycleAlerts();
+    rafId = requestAnimationFrame(loop);
+  }
+  toggle?.addEventListener('click', () => {
+    running = !running;
+    toggle.textContent = running ? 'Pause Demo' : 'Start Demo';
+    toggle.setAttribute('aria-pressed', running ? 'true' : 'false');
+    if (running) loop(); else cancelAnimationFrame(rafId);
+  });
+  speedInput?.addEventListener('input', e => cfg.speed = parseFloat(e.target.value));
+})();
+
+// Hero particles
+(function(){
+  const c = document.getElementById('heroParticles');
+  if (!c) return;
+  const ctx = c.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  let w, h, dots;
+
+  function resize(){
+    const rect = c.getBoundingClientRect();
+    w = c.width = rect.width * dpr; h = c.height = rect.height * dpr;
+    c.style.width = rect.width + 'px'; c.style.height = rect.height + 'px';
+    dots = Array.from({length: 70}, () => ({
+      x: Math.random()*w, y: Math.random()*h,
+      vx: (Math.random()-0.5)*0.2*dpr, vy:(Math.random()-0.5)*0.2*dpr
+    }));
+  }
+  function step(){
+    ctx.clearRect(0,0,w,h);
+    ctx.fillStyle = '#3d7fff';
+    dots.forEach(p=>{
+      p.x+=p.vx; p.y+=p.vy;
+      if (p.x<0||p.x>w) p.vx*=-1;
+      if (p.y<0||p.y>h) p.vy*=-1;
+      ctx.beginPath(); ctx.arc(p.x,p.y,1.4*dpr,0,Math.PI*2); ctx.fill();
+    });
+    requestAnimationFrame(step);
+  }
+  window.addEventListener('resize', resize, { passive: true });
+  resize(); step();
+})();

--- a/styles.css
+++ b/styles.css
@@ -168,6 +168,19 @@ section {
   .features-grid { grid-template-columns: repeat(5,1fr); }
 }
 
+.feature-item {
+  background: rgba(255,255,255,0.035);
+  border: 1px solid rgba(61,127,255,0.18);
+  border-radius: 12px;
+  padding: 1rem;
+  transition: transform .25s ease, border-color .25s ease, box-shadow .25s ease;
+}
+.feature-item:hover, .feature-item.in-view {
+  transform: translateY(-4px);
+  border-color: rgba(61,127,255,0.45);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+}
+
 /* Testimonials */
 .testimonial-carousel {
   position: relative;
@@ -248,3 +261,47 @@ footer {
   padding: 1rem;
   background: #000;
 }
+
+/* Hero glow and particles */
+.hero {
+  position: relative;
+  isolation: isolate;
+}
+.hero::after {
+  content:"";
+  position:absolute; inset:-20% -10% auto -10%; height:60%;
+  background: radial-gradient(600px 300px at 50% 40%, rgba(61,127,255,0.25), transparent 60%);
+  filter: blur(40px);
+  z-index:-1;
+}
+#heroParticles {
+  position:absolute; inset:0; width:100%; height:100%;
+  pointer-events:none; opacity:0.35;
+}
+
+/* Live Demo */
+.live-demo { padding-top: 2rem; }
+.demo-sub { color: var(--text-muted); margin-top: -0.5rem; }
+.monitor {
+  background: #0b1226;
+  border: 1px solid #14254d;
+  border-radius: 14px;
+  padding: 1rem;
+  display: grid;
+  gap: 12px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+}
+.demo-controls {
+  display: flex; gap: 1rem; align-items: center; margin-top: 1rem;
+}
+.speed span { margin-right: 0.5rem; color: var(--text-muted); }
+.alert-bar {
+  margin-top: 1rem;
+  display: flex; gap: 8px; flex-wrap: wrap;
+}
+.pill {
+  border: 1px solid #1f437c; color: #cbd8ff; padding: 6px 10px; border-radius: 999px;
+  font-size: 0.8rem; background: rgba(61,127,255,0.08);
+}
+.pill.warn { border-color: #ffb84d; background: rgba(255,184,77,0.1); color: #ffd9a1; }
+.pill.alert { border-color: #ff5a5a; background: rgba(255,90,90,0.08); color: #ffc1c1; }


### PR DESCRIPTION
## Summary
- Replace solution illustration and hero CTA; add hero particle canvas for visual depth.
- Introduce Live AI Monitor demo section with canvases and controls for simulated EMG/SSEP/MEP signals.
- Enhance UI with feature hover effects, glow and particle styling, plus supporting CSS/JS.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c46fe040832eb3e07e113fe4a42a